### PR TITLE
Add support for older macOS versions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -38,11 +38,7 @@ jobs:
 
       - name: Install poetry
         shell: bash
-        run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            choco install innosetup
-          fi
-          pip3 install poetry==${{ matrix.poetry-version }}
+        run: pip3 install poetry==${{ matrix.poetry-version }}
 
       - name: Disable virtualenvs
         run: poetry config virtualenvs.create false

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -8,8 +8,6 @@ on:
 
 jobs:
   build-release:
-    env:
-      MACOSX_DEPLOYMENT_TARGET: 10.9
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -36,10 +36,13 @@ jobs:
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}.9
 
-      - name: Run image
-        uses: abatilo/actions-poetry@v2.0.0
-        with:
-          poetry-version: ${{ matrix.poetry-version }}
+      - name: Install poetry
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            choco install innosetup
+          fi
+          pip3 install poetry==${{ matrix.poetry-version }}
 
       - name: Disable virtualenvs
         run: poetry config virtualenvs.create false

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build-release:
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 10.9
     strategy:
       fail-fast: false
       matrix:
@@ -17,9 +19,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        if: matrix.os != 'macOS-latest'
         with:
           python-version: ${{ matrix.python-version }}
+
+      # Based on: https://github.com/actions/virtual-environments/issues/1256#issuecomment-770270252
+      - name: Set up Python for macOS
+        if: matrix.os == 'macOS-latest'
+        run: |
+          curl https://www.python.org/ftp/python/${PYTHON_VERSION}/python-${PYTHON_VERSION}-macosx10.9.pkg -o "python.pkg"
+          sudo installer -pkg python.pkg -target /
+          echo "/Library/Frameworks/Python.framework/Versions/${{ matrix.python-version }}/bin" >> $GITHUB_PATH
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}.9
 
       - name: Run image
         uses: abatilo/actions-poetry@v2.0.0


### PR DESCRIPTION
There seems to be a Python library built for a newer version of macOS:

```
[18162] Error loading Python lib '/Users/user/Downloads/aw-watcher-utilization-macos-latest/libpython3.9.dylib': dlopen: dlopen(/Users/user/Downloads/aw-watcher-utilization-macos-latest/libpython3.9.dylib, 10): Symbol not found: ____chkstk_darwin
  Referenced from: /Users/user/Downloads/aw-watcher-utilization-macos-latest/libintl.8.dylib (which was built for Mac OS X 11.0)
  Expected in: /usr/lib/libSystem.B.dylib
 in /Users/user/Downloads/aw-watcher-utilization-macos-latest/libintl.8.dylib
```

So, this PR adds support for older macOS versions by building on Python for Mac OS X 10.9