### PR TITLE
Small language changes in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ On supported devices you also see fan and battery metrics.
 ## Install
 1. Download the latest release [here](https://github.com/Alwinator/aw-watcher-utilization/releases)
 2. Unzip as aw-watcher-utilization folder
-3. Move the folder to your activity watch directory
+3. Move the folder to your [activity watch directory](https://docs.activitywatch.net/en/latest/directories.html#data)
 4. Go to the [config directory](https://docs.activitywatch.net/en/latest/directories.html#config). In the aw-qt directory find the aw-qt.toml file.
 5. Add the aw-table-utilization to autostart_modules to enable auto-start. It should look like this:
 

--- a/README.md
+++ b/README.md
@@ -333,13 +333,13 @@ It creates a data dump every n-seconds. (n can be changed in the config, default
 </pre>
 </details>
 
-On supported devices you also see fan and battery metrics.
+On supported devices, you also see fan and battery metrics.
 
 ## Install
 1. Download the latest release [here](https://github.com/Alwinator/aw-watcher-utilization/releases).
 2. Unzip as aw-watcher-utilization folder.
 3. Move the folder to your [ActivityWatch directory](https://docs.activitywatch.net/en/latest/directories.html#data).
-4. Go to the [config directory](https://docs.activitywatch.net/en/latest/directories.html#config). In the aw-qt directory find the aw-qt.toml file.
+4. Go to the [config directory](https://docs.activitywatch.net/en/latest/directories.html#config). In the aw-qt directory, find the aw-qt.toml file.
 5. Add the aw-table-utilization to autostart_modules to enable auto-start. It should look like this:
 
 aw-qt.toml:
@@ -353,7 +353,7 @@ chmod +x ./aw-watcher-utilization
 ```
 
 ## Testing
-Unfortunately, I have a limited amount of computers, so bug reports are always very welcomed!
+Unfortunately, I have a limited number of computers, so bug reports are always very welcome!
 
 ## Contribute
 Thanks in advance!

--- a/README.md
+++ b/README.md
@@ -336,9 +336,9 @@ It creates a data dump every n-seconds. (n can be changed in the config, default
 On supported devices you also see fan and battery metrics.
 
 ## Install
-1. Download the latest release [here](https://github.com/Alwinator/aw-watcher-utilization/releases)
-2. Unzip as aw-watcher-utilization folder
-3. Move the folder to your [ActivityWatch directory](https://docs.activitywatch.net/en/latest/directories.html#data)
+1. Download the latest release [here](https://github.com/Alwinator/aw-watcher-utilization/releases).
+2. Unzip as aw-watcher-utilization folder.
+3. Move the folder to your [ActivityWatch directory](https://docs.activitywatch.net/en/latest/directories.html#data).
 4. Go to the [config directory](https://docs.activitywatch.net/en/latest/directories.html#config). In the aw-qt directory find the aw-qt.toml file.
 5. Add the aw-table-utilization to autostart_modules to enable auto-start. It should look like this:
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ It creates a data dump every `n` seconds. (`n` can be changed in the config, def
 
 On supported devices, you also see fan and battery metrics.
 
-## Install
+## Installing
 1. Download the latest release [here](https://github.com/Alwinator/aw-watcher-utilization/releases).
 2. Unzip as `aw-watcher-utilization` folder.
 3. Move the folder to your [ActivityWatch directory](https://docs.activitywatch.net/en/latest/directories.html#data).
@@ -355,7 +355,7 @@ chmod +x ./aw-watcher-utilization
 ## Testing
 Unfortunately, I have a limited number of computers, so bug reports are always very welcome!
 
-## Contribute
+## Contributing
 See [`DEV_SETUP.md`](DEV_SETUP.md).
 
 Thanks in advance!

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ On supported devices, you also see fan and battery metrics.
 [aw-qt]
 autostart_modules = ["aw-server", "aw-watcher-afk", "aw-watcher-window", "aw-watcher-utilization"]
 ```
-5. [Linux only]: Make the executable file in the `aw-watcher-utilization` folder executable:
+6. [Linux only]: Make the executable file in the `aw-watcher-utilization` folder executable:
 ```
 chmod +x ./aw-watcher-utilization
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Create releases for Linux and Windows](https://github.com/Alwinator/aw-watcher-utilization/actions/workflows/build-release.yml/badge.svg)](https://github.com/Alwinator/aw-watcher-utilization/actions/workflows/build-release.yml)
 [![stars](https://img.shields.io/github/stars/Alwinator/aw-watcher-utilization)](https://github.com/Alwinator/aw-watcher-utilization)
 
-An [Activity Watch](https://github.com/ActivityWatch/activitywatch) watcher that monitors CPU, RAM, disk, network, and sensor usage. It is basically a [psutil](https://github.com/giampaolo/psutil) wrapper for [Activity Watch](https://github.com/ActivityWatch/activitywatch). I have only left out some information that was too detailed.
+An [ActivityWatch](https://github.com/ActivityWatch/activitywatch) watcher that monitors CPU, RAM, disk, network, and sensor usage. It is basically a [psutil](https://github.com/giampaolo/psutil) wrapper for [ActivityWatch](https://github.com/ActivityWatch/activitywatch). I have only left out some information that was too detailed.
 
 It creates a data dump every n-seconds. (n can be changed in the config, default 5 seconds). Here is an example data dump:
 <details>
@@ -338,7 +338,7 @@ On supported devices you also see fan and battery metrics.
 ## Install
 1. Download the latest release [here](https://github.com/Alwinator/aw-watcher-utilization/releases)
 2. Unzip as aw-watcher-utilization folder
-3. Move the folder to your [activity watch directory](https://docs.activitywatch.net/en/latest/directories.html#data)
+3. Move the folder to your [ActivityWatch directory](https://docs.activitywatch.net/en/latest/directories.html#data)
 4. Go to the [config directory](https://docs.activitywatch.net/en/latest/directories.html#config). In the aw-qt directory find the aw-qt.toml file.
 5. Add the aw-table-utilization to autostart_modules to enable auto-start. It should look like this:
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![Create releases for Linux and Windows](https://github.com/Alwinator/aw-watcher-utilization/actions/workflows/build-release.yml/badge.svg)](https://github.com/Alwinator/aw-watcher-utilization/actions/workflows/build-release.yml)
 [![stars](https://img.shields.io/github/stars/Alwinator/aw-watcher-utilization)](https://github.com/Alwinator/aw-watcher-utilization)
 
-An [ActivityWatch](https://github.com/ActivityWatch/activitywatch) watcher that monitors CPU, RAM, disk, network, and sensor usage. It is basically a [psutil](https://github.com/giampaolo/psutil) wrapper for [ActivityWatch](https://github.com/ActivityWatch/activitywatch). I have only left out some information that was too detailed.
+An [ActivityWatch](https://github.com/ActivityWatch/activitywatch) watcher that monitors CPU, RAM, disk, network, and sensor usage. It is basically a [`psutil`](https://github.com/giampaolo/psutil) wrapper for [ActivityWatch](https://github.com/ActivityWatch/activitywatch). I have only left out some information that was too detailed.
 
-It creates a data dump every n-seconds. (n can be changed in the config, default 5 seconds). Here is an example data dump:
+It creates a data dump every `n` seconds. (`n` can be changed in the config, default 5 seconds). Here is an example data dump:
 <details>
 <summary>Expand to see the data dump</summary>
 <pre>
@@ -337,17 +337,17 @@ On supported devices, you also see fan and battery metrics.
 
 ## Install
 1. Download the latest release [here](https://github.com/Alwinator/aw-watcher-utilization/releases).
-2. Unzip as aw-watcher-utilization folder.
+2. Unzip as `aw-watcher-utilization` folder.
 3. Move the folder to your [ActivityWatch directory](https://docs.activitywatch.net/en/latest/directories.html#data).
-4. Go to the [config directory](https://docs.activitywatch.net/en/latest/directories.html#config). In the aw-qt directory, find the aw-qt.toml file.
-5. Add the aw-table-utilization to autostart_modules to enable auto-start. It should look like this:
+4. Go to the [config directory](https://docs.activitywatch.net/en/latest/directories.html#config). In the `aw-qt` directory, find the `aw-qt.toml` file.
+5. Add the `aw-table-utilization` to `autostart_modules` to enable auto-start. It should look like this:
 
-aw-qt.toml:
+`aw-qt.toml`:
 ```
 [aw-qt]
 autostart_modules = ["aw-server", "aw-watcher-afk", "aw-watcher-window", "aw-watcher-utilization"]
 ```
-5. [Linux only]: Make the executable file in the aw-watcher-utilization folder executable:
+5. [Linux only]: Make the executable file in the `aw-watcher-utilization` folder executable:
 ```
 chmod +x ./aw-watcher-utilization
 ```
@@ -358,4 +358,4 @@ Unfortunately, I have a limited number of computers, so bug reports are always v
 ## Contribute
 Thanks in advance!
 
-See [DEV_SETUP](DEV_SETUP.md).
+See [`DEV_SETUP.md`](DEV_SETUP.md).

--- a/README.md
+++ b/README.md
@@ -356,6 +356,6 @@ chmod +x ./aw-watcher-utilization
 Unfortunately, I have a limited number of computers, so bug reports are always very welcome!
 
 ## Contribute
-Thanks in advance!
-
 See [`DEV_SETUP.md`](DEV_SETUP.md).
+
+Thanks in advance!


### PR DESCRIPTION
- [`5660e91` Add a link to the list of directories](https://github.com/Alwinator/aw-watcher-utilization/commit/5660e9140e5bb280e45549fa8b6256d4e3188135) – It's now easier to understand what "ActivityWatch directory" means
- [`8101e0f` Type "ActivityWatch" correctly](https://github.com/Alwinator/aw-watcher-utilization/commit/8101e0f3647475dd9a187459afb5ade78b60a732) – It should be typed "ActivityWatch"
- [`9fefe56` Add a full stop after each sentence](https://github.com/Alwinator/aw-watcher-utilization/commit/9fefe56b7237abc141127969f580b95f70b0229f) – For consistency
- [`704b5c8` Small language changes](https://github.com/Alwinator/aw-watcher-utilization/commit/704b5c8dffbbce31a31a7d8ceda924bcfe6a31e9) – The sentence in the Testing section sounded a little weird to me, so I changed it...
- [`ea077d3` Add backticks before and after some terms](https://github.com/Alwinator/aw-watcher-utilization/commit/ea077d38e677e5ae3215b456cf9b85623ca2b9b5) – It's now clearer I guess...
- [`3aad9b7` Change the Contribute section a bit](https://github.com/Alwinator/aw-watcher-utilization/commit/3aad9b7a903d45806dec0ff1230cde65551c4da3) – Again, I found it strange to thank first and then point to `DEV_SETUP.md`
- [`f27d10c` Use gerund verbs in headings](https://github.com/Alwinator/aw-watcher-utilization/commit/f27d10cc043f2079161984b290a7284c18d226a2) – I think personal preferences, but now it seems better to me
- [`e4ee993` Correct the last step number](https://github.com/Alwinator/aw-watcher-utilization/commit/e4ee993650606babd02bb48ea693a2c7fa4083fa) – It should be `6`, not `5`